### PR TITLE
Add optional CD audio build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+NEED/
+nfs.cue
+nfs.bin
+FD14BOOT.img
+FD14-LiveCD.zip
+FD14LIVE.iso
+Need_for_Speed_SE.7z
+Road & Track Presents - The Need for Speed SE (USA) (Rerelease).zip
+/qemu-0.10.0/NEED.bat
+/qemu-0.10.0/NFSSE.iso
+/qemu-0.10.0/disk.img
+/qemu-0.10.0/hda.img
+/qemu-0.10.0/mydisk.img
+/qemu-0.10.0/NEED/
+/qemu-0.10.0/nfs.cue
+/qemu-0.10.0/nfs.bin
+/qemu-0.10.0/FD14BOOT.img
+/qemu-0.10.0/FD14-LiveCD.zip
+/qemu-0.10.0/FD14LIVE.iso
+/qemu-0.10.0/Need_for_Speed_SE.7z
+/qemu-0.10.0/Road & Track Presents - The Need for Speed SE (USA) (Rerelease).zip

--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
 # qemu_1.10
+
+This repository contains QEMU 0.10 with additional patches. Building the
+project requires some development libraries which may not be installed on a
+fresh system. The `scripts/install_sdl12.sh` helper can install the SDL 1.2
+headers used by the build.
+
+## Quick start
+
+```sh
+./scripts/install_sdl12.sh     # installs libsdl1.2-dev if needed
+cd qemu-0.10.0
+./configure --target-list=i386-softmmu [--enable-cdaudio]
+make -j$(nproc)
+```
+
+Passing `--enable-cdaudio` compiles the experimental CD audio support. Omit
+the option to build without it.
+
+The resulting `i386-softmmu/qemu` binary can then be run using your preferred
+arguments.
+
+## Quick disk test
+
+After building, you can create a small qcow2 disk image and boot QEMU with it:
+
+```sh
+./scripts/run_test_disk.sh               # creates 'disk.img' and boots it
+```
+
+The script uses `qemu-img` to create a 64MB image if it does not exist and
+passes it as the `-hda` drive.

--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ headers used by the build.
 ```sh
 ./scripts/install_sdl12.sh     # installs libsdl1.2-dev if needed
 cd qemu-0.10.0
-./configure --target-list=i386-softmmu [--enable-cdaudio]
-make -j$(nproc)
+./compilation.sh               # builds i386-softmmu with -m32 and CD audio
 ```
 
 Passing `--enable-cdaudio` compiles the experimental CD audio support. Omit
@@ -26,7 +25,17 @@ After building, you can create a small qcow2 disk image and boot QEMU with it:
 
 ```sh
 ./scripts/run_test_disk.sh               # creates 'disk.img' and boots it
+# QUIET=1 ./scripts/run_test_disk.sh     # run silently
 ```
 
 The script uses `qemu-img` to create a 64MB image if it does not exist and
 passes it as the `-hda` drive.
+
+To run a game that uses CD audio, pass the `.cue` file to QEMU:
+
+```sh
+DEBUG_PRINTS=1 ./qemu-0.10.0/i386-softmmu/qemu -L ./qemu-0.10.0/pc-bios \
+    -cdrom path/to/game.cue -m 64
+```
+
+Unset `DEBUG_PRINTS` to hide the additional debug output.

--- a/qemu-0.10.0/Makefile.target
+++ b/qemu-0.10.0/Makefile.target
@@ -558,6 +558,10 @@ ifdef CONFIG_BLUEZ
 LIBS += $(CONFIG_BLUEZ_LIBS)
 endif
 
+ifdef CONFIG_CDAUDIO
+CDROM_OBJ = cdaudio.o
+endif
+
 # SCSI layer
 OBJS+= lsi53c895a.o esp.o
 
@@ -579,7 +583,7 @@ OBJS += msmouse.o
 
 ifeq ($(TARGET_BASE_ARCH), i386)
 # Hardware support
-OBJS+= ide.o cdaudio.o pckbd.o ps2.o vga.o $(SOUND_HW) dma.o
+OBJS+= ide.o $(CDROM_OBJ) pckbd.o ps2.o vga.o $(SOUND_HW) dma.o
 OBJS+= fdc.o mc146818rtc.o serial.o i8259.o i8254.o pcspk.o pc.o
 OBJS+= cirrus_vga.o apic.o parallel.o acpi.o piix_pci.o
 OBJS+= usb-uhci.o vmmouse.o vmport.o vmware_vga.o hpet.o
@@ -589,7 +593,7 @@ endif
 ifeq ($(TARGET_BASE_ARCH), ppc)
 CPPFLAGS += -DHAS_AUDIO -DHAS_AUDIO_CHOICE
 # shared objects
-OBJS+= ppc.o ide.o cdaudio.o vga.o $(SOUND_HW) dma.o openpic.o
+OBJS+= ppc.o ide.o $(CDROM_OBJ) vga.o $(SOUND_HW) dma.o openpic.o
 # PREP target
 OBJS+= pckbd.o ps2.o serial.o i8259.o i8254.o fdc.o m48t59.o mc146818rtc.o
 OBJS+= prep_pci.o ppc_prep.o
@@ -616,7 +620,7 @@ ifeq ($(TARGET_BASE_ARCH), mips)
 OBJS+= mips_r4k.o mips_jazz.o mips_malta.o mips_mipssim.o
 OBJS+= mips_timer.o mips_int.o dma.o vga.o serial.o i8254.o i8259.o rc4030.o
 OBJS+= g364fb.o jazz_led.o
-OBJS+= ide.o gt64xxx.o cdaudio.o pckbd.o ps2.o fdc.o mc146818rtc.o usb-uhci.o acpi.o ds1225y.o
+OBJS+= ide.o gt64xxx.o $(CDROM_OBJ) pckbd.o ps2.o fdc.o mc146818rtc.o usb-uhci.o acpi.o ds1225y.o
 OBJS+= piix_pci.o parallel.o cirrus_vga.o pcspk.o $(SOUND_HW)
 OBJS+= mipsnet.o
 OBJS+= pflash_cfi01.o
@@ -639,7 +643,7 @@ OBJS+= pflash_cfi02.o nand.o
 endif
 ifeq ($(TARGET_BASE_ARCH), sparc)
 ifeq ($(TARGET_ARCH), sparc64)
-OBJS+= sun4u.o ide.o cdaudio.o pckbd.o ps2.o vga.o apb_pci.o
+OBJS+= sun4u.o ide.o $(CDROM_OBJ) pckbd.o ps2.o vga.o apb_pci.o
 OBJS+= fdc.o mc146818rtc.o serial.o m48t59.o
 OBJS+= cirrus_vga.o parallel.o ptimer.o
 else
@@ -659,7 +663,7 @@ OBJS+= arm-semi.o
 OBJS+= pxa2xx.o pxa2xx_pic.o pxa2xx_gpio.o pxa2xx_timer.o pxa2xx_dma.o
 OBJS+= pxa2xx_lcd.o pxa2xx_mmci.o pxa2xx_pcmcia.o pxa2xx_keypad.o
 OBJS+= pflash_cfi01.o gumstix.o
-OBJS+= zaurus.o ide.o cdaudio.o serial.o nand.o ecc.o spitz.o tosa.o tc6393xb.o
+OBJS+= zaurus.o ide.o $(CDROM_OBJ) serial.o nand.o ecc.o spitz.o tosa.o tc6393xb.o
 OBJS+= omap1.o omap_lcdc.o omap_dma.o omap_clk.o omap_mmc.o omap_i2c.o
 OBJS+= omap2.o omap_dss.o soc_dma.o
 OBJS+= omap_sx1.o palm.o tsc210x.o
@@ -672,7 +676,7 @@ endif
 ifeq ($(TARGET_BASE_ARCH), sh4)
 OBJS+= shix.o r2d.o sh7750.o sh7750_regnames.o tc58128.o
 OBJS+= sh_timer.o ptimer.o sh_serial.o sh_intc.o sh_pci.o sm501.o serial.o
-OBJS+= ide.o cdaudio.o
+OBJS+= ide.o $(CDROM_OBJ)
 endif
 ifeq ($(TARGET_BASE_ARCH), m68k)
 OBJS+= an5206.o mcf5206.o ptimer.o mcf_uart.o mcf_intc.o mcf5208.o mcf_fec.o

--- a/qemu-0.10.0/compilation.sh
+++ b/qemu-0.10.0/compilation.sh
@@ -1,0 +1,5 @@
+export CFLAGS="-m32"
+export LDFLAGS="-m32 -no-pie"
+./configure --target-list=i386-softmmu  --enable-cdaudio
+make clean
+make

--- a/qemu-0.10.0/configure
+++ b/qemu-0.10.0/configure
@@ -21,6 +21,7 @@ TMPSDLLOG="${TMPDIR1}/qemu-conf-sdl-$$-${RANDOM}.log"
 trap "rm -f $TMPC $TMPO $TMPE $TMPS $TMPI $TMPSDLLOG; exit" 0 2 3 15
 
 # default parameters
+cdaudio="no"
 prefix=""
 interp_prefix="/usr/gnemul/qemu-%M"
 static="no"
@@ -402,6 +403,10 @@ for opt do
   ;;
   --enable-profiler) profiler="yes"
   ;;
+  --enable-cdaudio) cdaudio="yes"
+  ;;
+  --disable-cdaudio) cdaudio="no"
+  ;;
   --enable-cocoa)
       cocoa="yes" ;
       sdl="no" ;
@@ -543,6 +548,8 @@ echo "                           Available drivers: $audio_possible_drivers"
 echo "  --audio-card-list=LIST   set list of emulated audio cards [$audio_card_list]"
 echo "                           Available cards: $audio_possible_cards"
 echo "  --enable-mixemu          enable mixer emulation"
+echo "  --enable-cdaudio         enable experimental CD audio support"
+echo "  --disable-cdaudio        disable CD audio"
 echo "  --disable-brlapi         disable BrlAPI"
 echo "  --disable-vnc-tls        disable TLS encryption for VNC server"
 echo "  --disable-curses         disable curses output"
@@ -1439,6 +1446,10 @@ if test "$bluez" = "yes" ; then
   echo "CONFIG_BLUEZ_CFLAGS=$bluez_cflags" >> $config_mak
   echo "CONFIG_BLUEZ_LIBS=$bluez_libs" >> $config_mak
   echo "#define CONFIG_BLUEZ 1" >> $config_h
+fi
+if test "$cdaudio" = "yes" ; then
+  echo "CONFIG_CDAUDIO=yes" >> $config_mak
+  echo "#define CONFIG_CDAUDIO 1" >> $config_h
 fi
 if test "$aio" = "yes" ; then
   echo "#define CONFIG_AIO 1" >> $config_h

--- a/qemu-0.10.0/cpu-exec.c
+++ b/qemu-0.10.0/cpu-exec.c
@@ -19,6 +19,7 @@
  */
 #include "config.h"
 #include <stdio.h>
+#include "debug_print.h"
 #define CPU_NO_GLOBAL_REGS
 #include "exec.h"
 #include "disas.h"
@@ -54,7 +55,7 @@ int tb_invalidated_flag;
 
 void cpu_loop_exit(void)
 {
-    fprintf(stderr, "cpu_loop_exit: env=%p\n", env);
+    DPRINTF("cpu_loop_exit: env=%p\n", env);
     /* NOTE: the register at this point must be saved by hand because
        longjmp restore them */
     regs_to_env();
@@ -99,7 +100,7 @@ static void cpu_exec_nocache(int max_cycles, TranslationBlock *orig_tb)
     unsigned long next_tb;
     TranslationBlock *tb;
 
-    fprintf(stderr, "cpu_exec_nocache: pc=0x%lx flags=0x%x\n",
+    DPRINTF("cpu_exec_nocache: pc=0x%lx flags=0x%x\n",
             (long)orig_tb->pc, orig_tb->flags);
 
     /* Should never happen.
@@ -129,7 +130,7 @@ static TranslationBlock *tb_find_slow(target_ulong pc,
     TranslationBlock *tb, **ptb1;
     unsigned int h;
     target_ulong phys_pc, phys_page1, phys_page2, virt_page2;
-    fprintf(stderr, "tb_find_slow: pc=0x%lx cs_base=0x%lx flags=0x%lx\n", (long)pc, (long)cs_base, (long)flags);
+    DPRINTF("tb_find_slow: pc=0x%lx cs_base=0x%lx flags=0x%lx\n", (long)pc, (long)cs_base, (long)flags);
 
     tb_invalidated_flag = 0;
 
@@ -165,11 +166,11 @@ static TranslationBlock *tb_find_slow(target_ulong pc,
  not_found:
   /* if no translated code available, then translate it now */
     tb = tb_gen_code(env, pc, cs_base, flags, 0);
-    fprintf(stderr, "tb_find_slow: generated tb=%p for pc=0x%lx\n", tb, (long)pc);
+    DPRINTF("tb_find_slow: generated tb=%p for pc=0x%lx\n", tb, (long)pc);
 
  found:
   /* we add the TB in the virtual pc hash table */
-    fprintf(stderr, "tb_find_slow: storing tb=%p in jmp_cache index=%zu\n", tb,
+    DPRINTF("tb_find_slow: storing tb=%p in jmp_cache index=%zu\n", tb,
             (size_t)tb_jmp_cache_hash_func(pc));
     env->tb_jmp_cache[tb_jmp_cache_hash_func(pc)] = tb;
     return tb;
@@ -226,7 +227,7 @@ int cpu_exec(CPUState *env1)
     uint8_t *tc_ptr;
     unsigned long next_tb;
 
-    fprintf(stderr, "cpu_exec: start env=%p eip=0x%lx\n",
+    DPRINTF("cpu_exec: start env=%p eip=0x%lx\n",
             env1, (long)env1->eip);
 
     if (cpu_halted(env1) == EXCP_HALTED)
@@ -616,7 +617,7 @@ int cpu_exec(CPUState *env1)
 
                 while (env->current_tb) {
                     tc_ptr = tb->tc_ptr;
-                    fprintf(stderr, "cpu_exec: executing tb=%p pc=0x%lx\n", tb,
+                    DPRINTF("cpu_exec: executing tb=%p pc=0x%lx\n", tb,
                             (long)tb->pc);
                 /* execute the generated code */
 #if defined(__sparc__) && !defined(HOST_SOLARIS)
@@ -625,7 +626,7 @@ int cpu_exec(CPUState *env1)
 #define env cpu_single_env
 #endif
                     next_tb = tcg_qemu_tb_exec(tc_ptr);
-                    fprintf(stderr, "cpu_exec: next_tb=0x%lx after tb=%p\n",
+                    DPRINTF("cpu_exec: next_tb=0x%lx after tb=%p\n",
                             next_tb, tb);
                     env->current_tb = NULL;
                     if ((next_tb & 3) == 2) {
@@ -772,7 +773,7 @@ static inline int handle_cpu_signal(unsigned long pc, unsigned long address,
 {
     TranslationBlock *tb;
     int ret;
-    fprintf(stderr, "handle_cpu_signal: pc=0x%lx address=0x%lx write=%d\n",
+    DPRINTF("handle_cpu_signal: pc=0x%lx address=0x%lx write=%d\n",
             pc, address, is_write);
 
     if (cpu_single_env)

--- a/qemu-0.10.0/cpu-exec.c
+++ b/qemu-0.10.0/cpu-exec.c
@@ -18,6 +18,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston MA  02110-1301 USA
  */
 #include "config.h"
+#include <stdio.h>
 #define CPU_NO_GLOBAL_REGS
 #include "exec.h"
 #include "disas.h"
@@ -53,6 +54,7 @@ int tb_invalidated_flag;
 
 void cpu_loop_exit(void)
 {
+    fprintf(stderr, "cpu_loop_exit: env=%p\n", env);
     /* NOTE: the register at this point must be saved by hand because
        longjmp restore them */
     regs_to_env();
@@ -97,6 +99,9 @@ static void cpu_exec_nocache(int max_cycles, TranslationBlock *orig_tb)
     unsigned long next_tb;
     TranslationBlock *tb;
 
+    fprintf(stderr, "cpu_exec_nocache: pc=0x%lx flags=0x%x\n",
+            (long)orig_tb->pc, orig_tb->flags);
+
     /* Should never happen.
        We only end up here when an existing TB is too long.  */
     if (max_cycles > CF_COUNT_MASK)
@@ -124,6 +129,7 @@ static TranslationBlock *tb_find_slow(target_ulong pc,
     TranslationBlock *tb, **ptb1;
     unsigned int h;
     target_ulong phys_pc, phys_page1, phys_page2, virt_page2;
+    fprintf(stderr, "tb_find_slow: pc=0x%lx cs_base=0x%lx flags=0x%lx\n", (long)pc, (long)cs_base, (long)flags);
 
     tb_invalidated_flag = 0;
 
@@ -157,11 +163,14 @@ static TranslationBlock *tb_find_slow(target_ulong pc,
         ptb1 = &tb->phys_hash_next;
     }
  not_found:
-   /* if no translated code available, then translate it now */
+  /* if no translated code available, then translate it now */
     tb = tb_gen_code(env, pc, cs_base, flags, 0);
+    fprintf(stderr, "tb_find_slow: generated tb=%p for pc=0x%lx\n", tb, (long)pc);
 
  found:
-    /* we add the TB in the virtual pc hash table */
+  /* we add the TB in the virtual pc hash table */
+    fprintf(stderr, "tb_find_slow: storing tb=%p in jmp_cache index=%zu\n", tb,
+            (size_t)tb_jmp_cache_hash_func(pc));
     env->tb_jmp_cache[tb_jmp_cache_hash_func(pc)] = tb;
     return tb;
 }
@@ -216,6 +225,9 @@ int cpu_exec(CPUState *env1)
     TranslationBlock *tb;
     uint8_t *tc_ptr;
     unsigned long next_tb;
+
+    fprintf(stderr, "cpu_exec: start env=%p eip=0x%lx\n",
+            env1, (long)env1->eip);
 
     if (cpu_halted(env1) == EXCP_HALTED)
         return EXCP_HALTED;
@@ -604,6 +616,8 @@ int cpu_exec(CPUState *env1)
 
                 while (env->current_tb) {
                     tc_ptr = tb->tc_ptr;
+                    fprintf(stderr, "cpu_exec: executing tb=%p pc=0x%lx\n", tb,
+                            (long)tb->pc);
                 /* execute the generated code */
 #if defined(__sparc__) && !defined(HOST_SOLARIS)
 #undef env
@@ -611,6 +625,8 @@ int cpu_exec(CPUState *env1)
 #define env cpu_single_env
 #endif
                     next_tb = tcg_qemu_tb_exec(tc_ptr);
+                    fprintf(stderr, "cpu_exec: next_tb=0x%lx after tb=%p\n",
+                            next_tb, tb);
                     env->current_tb = NULL;
                     if ((next_tb & 3) == 2) {
                         /* Instruction counter expired.  */
@@ -756,6 +772,8 @@ static inline int handle_cpu_signal(unsigned long pc, unsigned long address,
 {
     TranslationBlock *tb;
     int ret;
+    fprintf(stderr, "handle_cpu_signal: pc=0x%lx address=0x%lx write=%d\n",
+            pc, address, is_write);
 
     if (cpu_single_env)
         env = cpu_single_env; /* XXX: find a correct solution for multithread */

--- a/qemu-0.10.0/debug_print.h
+++ b/qemu-0.10.0/debug_print.h
@@ -1,0 +1,6 @@
+#ifndef DEBUG_PRINT_H
+#define DEBUG_PRINT_H
+#include <stdio.h>
+extern int debug_prints;
+#define DPRINTF(...) do { if (debug_prints) fprintf(stderr, __VA_ARGS__); } while (0)
+#endif /* DEBUG_PRINT_H */

--- a/qemu-0.10.0/dyngen-exec.h
+++ b/qemu-0.10.0/dyngen-exec.h
@@ -82,14 +82,7 @@ typedef void * host_reg_t;
 #define UINT32_MAX		(4294967295U)
 #define UINT64_MAX		((uint64_t)(18446744073709551615))
 
-#ifdef _BSD
-typedef struct __sFILE FILE;
-#else
-typedef struct FILE FILE;
-#endif
-extern int fprintf(FILE *, const char *, ...);
-extern int fputs(const char *, FILE *);
-extern int printf(const char *, ...);
+#include <stdio.h>
 #undef NULL
 #define NULL 0
 

--- a/qemu-0.10.0/exec.c
+++ b/qemu-0.10.0/exec.c
@@ -854,6 +854,9 @@ TranslationBlock *tb_gen_code(CPUState *env,
     target_ulong phys_pc, phys_page2, virt_page2;
     int code_gen_size;
 
+    fprintf(stderr, "tb_gen_code: env=%p pc=0x%lx cs_base=0x%lx flags=0x%x\n",
+            env, (long)pc, (long)cs_base, flags);
+
     phys_pc = get_phys_addr_code(env, pc);
     tb = tb_alloc(pc);
     if (!tb) {
@@ -870,6 +873,8 @@ TranslationBlock *tb_gen_code(CPUState *env,
     tb->flags = flags;
     tb->cflags = cflags;
     cpu_gen_code(env, tb, &code_gen_size);
+    fprintf(stderr, "tb_gen_code: generated tb=%p tc_ptr=%p size=%d\n", tb,
+            tc_ptr, code_gen_size);
     code_gen_ptr = (void *)(((unsigned long)code_gen_ptr + code_gen_size + CODE_GEN_ALIGN - 1) & ~(CODE_GEN_ALIGN - 1));
 
     /* check next page if needed */
@@ -879,6 +884,8 @@ TranslationBlock *tb_gen_code(CPUState *env,
         phys_page2 = get_phys_addr_code(env, virt_page2);
     }
     tb_link_phys(tb, phys_pc, phys_page2);
+    fprintf(stderr, "tb_gen_code: linked tb=%p phys_pc=0x%lx phys_page2=0x%lx\n",
+            tb, (long)phys_pc, (long)phys_page2);
     return tb;
 }
 

--- a/qemu-0.10.0/exec.c
+++ b/qemu-0.10.0/exec.c
@@ -27,6 +27,7 @@
 #endif
 #include <stdlib.h>
 #include <stdio.h>
+#include "debug_print.h"
 #include <stdarg.h>
 #include <string.h>
 #include <errno.h>
@@ -854,7 +855,7 @@ TranslationBlock *tb_gen_code(CPUState *env,
     target_ulong phys_pc, phys_page2, virt_page2;
     int code_gen_size;
 
-    fprintf(stderr, "tb_gen_code: env=%p pc=0x%lx cs_base=0x%lx flags=0x%x\n",
+    DPRINTF("tb_gen_code: env=%p pc=0x%lx cs_base=0x%lx flags=0x%x\n",
             env, (long)pc, (long)cs_base, flags);
 
     phys_pc = get_phys_addr_code(env, pc);
@@ -873,7 +874,7 @@ TranslationBlock *tb_gen_code(CPUState *env,
     tb->flags = flags;
     tb->cflags = cflags;
     cpu_gen_code(env, tb, &code_gen_size);
-    fprintf(stderr, "tb_gen_code: generated tb=%p tc_ptr=%p size=%d\n", tb,
+    DPRINTF("tb_gen_code: generated tb=%p tc_ptr=%p size=%d\n", tb,
             tc_ptr, code_gen_size);
     code_gen_ptr = (void *)(((unsigned long)code_gen_ptr + code_gen_size + CODE_GEN_ALIGN - 1) & ~(CODE_GEN_ALIGN - 1));
 
@@ -884,7 +885,7 @@ TranslationBlock *tb_gen_code(CPUState *env,
         phys_page2 = get_phys_addr_code(env, virt_page2);
     }
     tb_link_phys(tb, phys_pc, phys_page2);
-    fprintf(stderr, "tb_gen_code: linked tb=%p phys_pc=0x%lx phys_page2=0x%lx\n",
+    DPRINTF("tb_gen_code: linked tb=%p phys_pc=0x%lx phys_page2=0x%lx\n",
             tb, (long)phys_pc, (long)phys_page2);
     return tb;
 }

--- a/qemu-0.10.0/hw/cdaudio.c
+++ b/qemu-0.10.0/hw/cdaudio.c
@@ -2,6 +2,8 @@
 #include "cdaudio.h"
 #include "bswap.h"
 
+#ifdef CONFIG_CDAUDIO
+
 typedef struct CDAudioState {
     QEMUSoundCard card;
     SWVoiceOut *voice;
@@ -76,3 +78,4 @@ void cdaudio_stop(void)
     if (cd_audio.voice)
         AUD_set_active_out(cd_audio.voice, 0);
 }
+#endif /* CONFIG_CDAUDIO */

--- a/qemu-0.10.0/hw/cdaudio.h
+++ b/qemu-0.10.0/hw/cdaudio.h
@@ -4,10 +4,18 @@
 #include "block.h"
 #include "audio/audio.h"
 
+#ifdef CONFIG_CDAUDIO
 void cdaudio_init(BlockDriverState *bs);
 void cdaudio_set_bs(BlockDriverState *bs);
 void cdaudio_play_lba(int start_lba, int nb_sectors);
 void cdaudio_pause(int active);
 void cdaudio_stop(void);
+#else
+static inline void cdaudio_init(BlockDriverState *bs) {}
+static inline void cdaudio_set_bs(BlockDriverState *bs) {}
+static inline void cdaudio_play_lba(int start_lba, int nb_sectors) {}
+static inline void cdaudio_pause(int active) {}
+static inline void cdaudio_stop(void) {}
+#endif
 
 #endif /* CDAUDIO_H */

--- a/qemu-0.10.0/hw/cdrom.c
+++ b/qemu-0.10.0/hw/cdrom.c
@@ -49,6 +49,7 @@ int cdrom_read_toc(int nb_sectors, uint8_t *buf, int msf, int start_track)
     q = buf + 2;
     *q++ = 1; /* first session */
     *q++ = 1; /* last session */
+#ifdef CONFIG_CDAUDIO
     if (cue_sheet.track_count > 0) {
         int i;
         for (i = 0; i < cue_sheet.track_count; i++) {
@@ -67,7 +68,9 @@ int cdrom_read_toc(int nb_sectors, uint8_t *buf, int msf, int start_track)
                 q += 4;
             }
         }
-    } else if (start_track <= 1) {
+    } else
+#endif
+    if (start_track <= 1) {
         *q++ = 0; /* reserved */
         *q++ = 0x14; /* ADR, control */
         *q++ = 1;    /* track number */

--- a/qemu-0.10.0/hw/ide.c
+++ b/qemu-0.10.0/hw/ide.c
@@ -1800,11 +1800,14 @@ static void ide_atapi_cmd(IDEState *s)
         }
         break;
     case GPCMD_PLAY_AUDIO_10:
-        lba = ube32_to_cpu(packet + 2);
-        nb_sectors = ube16_to_cpu(packet + 7);
-        cdaudio_set_bs(s->bs);
-        cdaudio_play_lba(lba, nb_sectors);
-        ide_atapi_cmd_ok(s);
+        {
+            int lba, nb_sectors;
+            lba = ube32_to_cpu(packet + 2);
+            nb_sectors = ube16_to_cpu(packet + 7);
+            cdaudio_set_bs(s->bs);
+            cdaudio_play_lba(lba, nb_sectors);
+            ide_atapi_cmd_ok(s);
+        }
         break;
     case GPCMD_PLAY_AUDIO_MSF:
         { int start_lba = msf_to_lba_local(packet[3], packet[4], packet[5]);

--- a/qemu-0.10.0/readme.txt
+++ b/qemu-0.10.0/readme.txt
@@ -1,0 +1,144 @@
+###############################################################################
+		FreeDOS 1.4 ("FreeDOS 1.4")
+###############################################################################
+
+
+-------------------------------------------------------------------------------
+		General system requirements:
+-------------------------------------------------------------------------------
+
+  * DOS-compatible system (Intel + BIOS, or UEFI with Legacy support)
+
+  * At least 20MB free disk space:
+
+    20MB  Plain DOS system
+    30MB  Plain DOS system, with sources
+
+    275MB  Full installation including applications and games
+    450MB  Full installation with sources
+
+
+-------------------------------------------------------------------------------
+		What's in all those zip files?
+-------------------------------------------------------------------------------
+
+FD14-LiveCD.zip
+
+  * FD14BOOT.IMG - Basic FreeDOS installation boot floppy image.
+    If your computer has a CD-ROM drive, but you cannot boot from the Live CD
+    or Legacy CD. Use this diskette image to boot the system. Then insert the
+    install CD. The FreeDOS installer should do the rest. This diskette
+    image is for installation purposes only and does not provide a Live
+    Environment.
+
+  * FD14LIVE.ISO - The FreeDOS 1.4 installer.  Most users should
+    use this image to install FreeDOS.
+
+    Depending on your computer system and hardware configuration, you
+    can also use the LiveCD to boot and run FreeDOS directly from the
+    CD-ROM without installation to your hard drive.
+
+FD14-LegacyCD.zip
+
+  * FD14BOOT.IMG - This zip archive also contains a copy of the basic
+    CD-ROM installation boot floppy.
+
+  * FD14LGCY.ISO - A bootable CD image designed for older hardware. If
+    you cannot boot the LiveCD to install FreeDOS, try this disc image.
+
+    This disc image uses the older El Torito boot CD format. Some newer
+    computers and virtual machines cannot use this older format. Unless
+    you have a computer that requires this type of bootable CD, we
+    recommend using the LiveCD instead.
+
+FD14-BonusCD.zip
+
+  * FD14BNS.ISO - A non-bootable CD image that contains some FreeDOS
+    packages that are not installed as part of either the LiveCD or
+    the Legacy CD.
+
+FD14-LiteUSB.zip
+
+  * FD14LITE.IMG - A minimal FreeDOS installer, as a USB fob drive
+    image. This does not contain all of the packages from either the
+    LiveCD or the LegacyCD, and instead only contains a basic set of
+    FreeDOS packages.
+
+  * FD14LITE.VMDK - A virtual machine disk file, compatible with a
+    variety of virtual machine software including VirtualBox, VMware,
+    and other systems.
+
+    Using a VMDK file can simplify installing FreeDOS. Just attach the
+    VMDK image to your virtual machine software as a hard drive, and
+    boot it. (Please note that you will still need to create a virtual
+    hard disk to install FreeDOS)
+
+FD14-FullUSB.zip
+
+  * FD14FULL.IMG - Plain DOS system and Full install USB stick image.
+
+  * FD14FULL.VMDK - A virtual machine disk file, compatible with a
+    variety of virtual machine software. Just attach the VMDK image to
+    your virtual machine as a hard drive, and boot it.
+
+VERIFY.TXT
+
+  * Contains MD5, SHA256 and SHA512 hashes for all of the different
+    release files. You can verify your copy of FreeDOS with these.
+
+README.TXT
+
+  * The "before you choose and install" document. (All of the zip
+    files listed above also have a copy of the README file.)
+
+
+-------------------------------------------------------------------------------
+		FreeDOS Floppy-Only Edition (FD14-x86)
+-------------------------------------------------------------------------------
+
+FreeDOS 1.4 includes a Floppy-Only Edition! This edition should run on
+any hardware that can run FreeDOS and has EGA or better graphics:
+
+  * Are you running a '286 or another classic system without a CD-ROM
+    drive?  Install from these floppies to install FreeDOS.
+
+  * Do you have just one hard drive and no CD or floppy drive? Just
+    copy the contents of the floppies to a temporary directory and run
+    the installer from there.
+
+  * Want to perform a "headless" install to a different DOS directory?
+    It's easy with the command line options.
+
+The Floppy-Only Edition uses a completely different installer than
+the CD-ROM or USB installers. The Floppy-Only Edition does not use
+any of those other media to install.
+
+The Floppy-Only Edition contains a limited set of FreeDOS programs
+that are more useful on classic PC hardware.
+
+The FreeDOS Floppy-Only Edition is distributed as single zip archive that
+contains several pre-made floppy diskette images:
+
+    These zip archives contain image files for several common floppy
+    diskette media under separate directories:
+
+    * 720k - 3.5" 720k diskette images
+
+    * 144m - 3.5" 1.44mb diskette images
+
+    * 120m - 5.25" 1.2mb diskette images
+
+    Each of those sets contain a number of pre-made disk images:
+
+    * x86BOOT.img - A floppy boot disk image with the x86 installer.
+
+    * x86DSK??.img - Several floppy diskette images that contain the
+      core FreeDOS operating system files. The number of floppy images
+      and amount of files on each varies depending on the diskette
+      capacity.
+
+To conserve space, the FreeDOS Floppy-Only Edition does not contain
+the source code for the FreeDOS packages. You can find the source code
+via the FreeDOS website (https://www.freedos.org/download/) or from
+the other release media, like the USB or CD-ROM installer.
+

--- a/qemu-0.10.0/readme_start.md
+++ b/qemu-0.10.0/readme_start.md
@@ -1,0 +1,1 @@
+./i386-softmmu/qemu -L pc-bios^Chda mydisk.img -serial mon:stdio

--- a/qemu-0.10.0/slirp/libslirp.h
+++ b/qemu-0.10.0/slirp/libslirp.h
@@ -5,7 +5,7 @@
 extern "C" {
 #endif
 
-void slirp_init(int restrict, char *special_ip);
+void slirp_init(int restricted, char *special_ip);
 
 void slirp_select_fill(int *pnfds,
                        fd_set *readfds, fd_set *writefds, fd_set *xfds);

--- a/qemu-0.10.0/slirp/slirp.c
+++ b/qemu-0.10.0/slirp/slirp.c
@@ -171,7 +171,7 @@ static void slirp_cleanup(void)
 static void slirp_state_save(QEMUFile *f, void *opaque);
 static int slirp_state_load(QEMUFile *f, void *opaque, int version_id);
 
-void slirp_init(int restrict, char *special_ip)
+void slirp_init(int restricted, char *special_ip)
 {
     //    debug_init("/tmp/slirp.log", DEBUG_DEFAULT);
 
@@ -184,7 +184,7 @@ void slirp_init(int restrict, char *special_ip)
 #endif
 
     link_up = 1;
-    slirp_restrict = restrict;
+    slirp_restrict = restricted;
 
     if_init();
     ip_init();

--- a/qemu-0.10.0/vl.c
+++ b/qemu-0.10.0/vl.c
@@ -21,6 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+#include <stdio.h>
 #include "hw/hw.h"
 #include "hw/boards.h"
 #include "hw/usb.h"
@@ -137,6 +138,7 @@
 #define memalign(align, size) malloc(size)
 #endif
 
+#ifdef CONFIG_CDAUDIO
 #define LINE_BUF_LEN 1024
 
 CueSheet cue_sheet;
@@ -213,6 +215,7 @@ static int cue_extract_bin(const char *cuefile, char *out, int out_size)
     }
     return -1;
 }
+#endif /* CONFIG_CDAUDIO */
 #ifdef CONFIG_SDL
 #ifdef __APPLE__
 #include <SDL/SDL.h>
@@ -3830,6 +3833,8 @@ static int main_loop(void)
 #endif
     CPUState *env;
 
+    fprintf(stderr, "main_loop: start\n");
+
     cur_cpu = first_cpu;
     next_cpu = cur_cpu->next_cpu ?: first_cpu;
     for(;;) {
@@ -3856,9 +3861,12 @@ static int main_loop(void)
                     env->icount_decr.u16.low = decr;
                     env->icount_extra = count;
                 }
+                fprintf(stderr, "main_loop: executing CPU env=%p pc=0x%lx\n", env,
+                        (long)env->eip);
                 ret = cpu_exec(env);
+                fprintf(stderr, "main_loop: cpu_exec returned %d\n", ret);
 #ifdef CONFIG_PROFILER
-                qemu_time += profile_getclock() - ti;
+            qemu_time += profile_getclock() - ti;
 #endif
                 if (use_icount) {
                     /* Fold pending instructions back into the

--- a/qemu-0.10.0/vl.c
+++ b/qemu-0.10.0/vl.c
@@ -38,6 +38,7 @@
 #include "qemu-timer.h"
 #include "qemu-char.h"
 #include "cache-utils.h"
+#include "debug_print.h"
 #include "block.h"
 #include "audio/audio.h"
 #include "migration.h"
@@ -326,6 +327,7 @@ int semihosting_enabled = 0;
 int old_param = 0;
 #endif
 const char *qemu_name;
+int debug_prints = 0;
 int alt_grab = 0;
 #if defined(TARGET_SPARC) || defined(TARGET_PPC)
 unsigned int nb_prom_envs = 0;
@@ -3833,7 +3835,7 @@ static int main_loop(void)
 #endif
     CPUState *env;
 
-    fprintf(stderr, "main_loop: start\n");
+    DPRINTF("main_loop: start\n");
 
     cur_cpu = first_cpu;
     next_cpu = cur_cpu->next_cpu ?: first_cpu;
@@ -3861,10 +3863,10 @@ static int main_loop(void)
                     env->icount_decr.u16.low = decr;
                     env->icount_extra = count;
                 }
-                fprintf(stderr, "main_loop: executing CPU env=%p pc=0x%lx\n", env,
+                DPRINTF("main_loop: executing CPU env=%p pc=0x%lx\n", env,
                         (long)env->eip);
                 ret = cpu_exec(env);
-                fprintf(stderr, "main_loop: cpu_exec returned %d\n", ret);
+                DPRINTF("main_loop: cpu_exec returned %d\n", ret);
 #ifdef CONFIG_PROFILER
             qemu_time += profile_getclock() - ti;
 #endif
@@ -4731,6 +4733,10 @@ int main(int argc, char **argv, char **envp)
     struct passwd *pwd = NULL;
     const char *chroot_dir = NULL;
     const char *run_as = NULL;
+
+    const char *dbg = getenv("DEBUG_PRINTS");
+    if (dbg && *dbg && strcmp(dbg, "0") != 0)
+        debug_prints = 1;
 
     qemu_cache_utils_init(envp);
 

--- a/scripts/install_sdl12.sh
+++ b/scripts/install_sdl12.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -e
+
+# Simple helper script to install SDL 1.2 development files on
+# Debian/Ubuntu systems. Useful when building QEMU from a fresh
+# environment without persistent package caches.
+
+PKG="libsdl1.2-dev"
+
+if dpkg -s "$PKG" >/dev/null 2>&1; then
+    echo "$PKG already installed"
+else
+    echo "Installing $PKG via apt-get..."
+    sudo apt-get update
+    sudo apt-get install -y "$PKG"
+fi

--- a/scripts/run_test_disk.sh
+++ b/scripts/run_test_disk.sh
@@ -14,4 +14,4 @@ if [ ! -f "$IMG" ]; then
 fi
 
 cd qemu-0.10.0
-exec ./i386-softmmu/qemu -hda "../$IMG" -m 64
+exec ./i386-softmmu/qemu -L ./pc-bios -hda "../$IMG" -m 64

--- a/scripts/run_test_disk.sh
+++ b/scripts/run_test_disk.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -e
 
+# Optional: set QUIET=1 to suppress command output
+
 # Simple helper to create a qcow2 disk image and boot QEMU with it.
 # Usage: ./scripts/run_test_disk.sh [image] [size]
 # Default image name is 'disk.img' and size is 64M.
@@ -9,9 +11,17 @@ SIZE=${2:-64M}
 
 # Create disk image if it doesn't already exist
 if [ ! -f "$IMG" ]; then
-    echo "Creating $IMG of size $SIZE"
-    qemu-img create -f qcow2 "$IMG" "$SIZE"
+    [ "$QUIET" = "1" ] || echo "Creating $IMG of size $SIZE"
+    if [ "$QUIET" = "1" ]; then
+        qemu-img create -f qcow2 "$IMG" "$SIZE" >/dev/null 2>&1
+    else
+        qemu-img create -f qcow2 "$IMG" "$SIZE"
+    fi
 fi
 
 cd qemu-0.10.0
-exec ./i386-softmmu/qemu -L ./pc-bios -hda "../$IMG" -m 64
+if [ "$QUIET" = "1" ]; then
+    exec ./i386-softmmu/qemu -L ./pc-bios -hda "../$IMG" -m 64 >/dev/null 2>&1
+else
+    exec ./i386-softmmu/qemu -L ./pc-bios -hda "../$IMG" -m 64
+fi

--- a/scripts/run_test_disk.sh
+++ b/scripts/run_test_disk.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -e
+
+# Simple helper to create a qcow2 disk image and boot QEMU with it.
+# Usage: ./scripts/run_test_disk.sh [image] [size]
+# Default image name is 'disk.img' and size is 64M.
+IMG=${1:-disk.img}
+SIZE=${2:-64M}
+
+# Create disk image if it doesn't already exist
+if [ ! -f "$IMG" ]; then
+    echo "Creating $IMG of size $SIZE"
+    qemu-img create -f qcow2 "$IMG" "$SIZE"
+fi
+
+cd qemu-0.10.0
+exec ./i386-softmmu/qemu -hda "../$IMG" -m 64


### PR DESCRIPTION
## Summary
- make CD audio support optional via `--enable-cdaudio`
- wrap new CD audio features behind `CONFIG_CDAUDIO`
- document the new configure flag in the README
- guard cuesheet usage when CD audio is disabled

## Testing
- `./configure --target-list=i386-softmmu --disable-cdaudio --disable-gfx-check --disable-sdl`
- `make -j$(nproc)`


------
https://chatgpt.com/codex/tasks/task_e_6851075f6604832c8465cffb138f3c8c