### PR TITLE
Add runtime debug toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ headers used by the build.
 ```sh
 ./scripts/install_sdl12.sh     # installs libsdl1.2-dev if needed
 cd qemu-0.10.0
-./configure --target-list=i386-softmmu [--enable-cdaudio]
-make -j$(nproc)
+./compilation.sh               # builds i386-softmmu with -m32 and CD audio
 ```
 
 Passing `--enable-cdaudio` compiles the experimental CD audio support. Omit
@@ -26,7 +25,17 @@ After building, you can create a small qcow2 disk image and boot QEMU with it:
 
 ```sh
 ./scripts/run_test_disk.sh               # creates 'disk.img' and boots it
+# QUIET=1 ./scripts/run_test_disk.sh     # run silently
 ```
 
 The script uses `qemu-img` to create a 64MB image if it does not exist and
 passes it as the `-hda` drive.
+
+To run a game that uses CD audio, pass the `.cue` file to QEMU:
+
+```sh
+DEBUG_PRINTS=1 ./qemu-0.10.0/i386-softmmu/qemu -L ./qemu-0.10.0/pc-bios \
+    -cdrom path/to/game.cue -m 64
+```
+
+Unset `DEBUG_PRINTS` to hide the additional debug output.

--- a/qemu-0.10.0/cpu-exec.c
+++ b/qemu-0.10.0/cpu-exec.c
@@ -19,6 +19,7 @@
  */
 #include "config.h"
 #include <stdio.h>
+#include "debug_print.h"
 #define CPU_NO_GLOBAL_REGS
 #include "exec.h"
 #include "disas.h"
@@ -54,7 +55,7 @@ int tb_invalidated_flag;
 
 void cpu_loop_exit(void)
 {
-    fprintf(stderr, "cpu_loop_exit: env=%p\n", env);
+    DPRINTF("cpu_loop_exit: env=%p\n", env);
     /* NOTE: the register at this point must be saved by hand because
        longjmp restore them */
     regs_to_env();
@@ -99,7 +100,7 @@ static void cpu_exec_nocache(int max_cycles, TranslationBlock *orig_tb)
     unsigned long next_tb;
     TranslationBlock *tb;
 
-    fprintf(stderr, "cpu_exec_nocache: pc=0x%lx flags=0x%x\n",
+    DPRINTF("cpu_exec_nocache: pc=0x%lx flags=0x%x\n",
             (long)orig_tb->pc, orig_tb->flags);
 
     /* Should never happen.
@@ -129,7 +130,7 @@ static TranslationBlock *tb_find_slow(target_ulong pc,
     TranslationBlock *tb, **ptb1;
     unsigned int h;
     target_ulong phys_pc, phys_page1, phys_page2, virt_page2;
-    fprintf(stderr, "tb_find_slow: pc=0x%lx cs_base=0x%lx flags=0x%lx\n", (long)pc, (long)cs_base, (long)flags);
+    DPRINTF("tb_find_slow: pc=0x%lx cs_base=0x%lx flags=0x%lx\n", (long)pc, (long)cs_base, (long)flags);
 
     tb_invalidated_flag = 0;
 
@@ -165,11 +166,11 @@ static TranslationBlock *tb_find_slow(target_ulong pc,
  not_found:
   /* if no translated code available, then translate it now */
     tb = tb_gen_code(env, pc, cs_base, flags, 0);
-    fprintf(stderr, "tb_find_slow: generated tb=%p for pc=0x%lx\n", tb, (long)pc);
+    DPRINTF("tb_find_slow: generated tb=%p for pc=0x%lx\n", tb, (long)pc);
 
  found:
   /* we add the TB in the virtual pc hash table */
-    fprintf(stderr, "tb_find_slow: storing tb=%p in jmp_cache index=%zu\n", tb,
+    DPRINTF("tb_find_slow: storing tb=%p in jmp_cache index=%zu\n", tb,
             (size_t)tb_jmp_cache_hash_func(pc));
     env->tb_jmp_cache[tb_jmp_cache_hash_func(pc)] = tb;
     return tb;
@@ -226,7 +227,7 @@ int cpu_exec(CPUState *env1)
     uint8_t *tc_ptr;
     unsigned long next_tb;
 
-    fprintf(stderr, "cpu_exec: start env=%p eip=0x%lx\n",
+    DPRINTF("cpu_exec: start env=%p eip=0x%lx\n",
             env1, (long)env1->eip);
 
     if (cpu_halted(env1) == EXCP_HALTED)
@@ -616,7 +617,7 @@ int cpu_exec(CPUState *env1)
 
                 while (env->current_tb) {
                     tc_ptr = tb->tc_ptr;
-                    fprintf(stderr, "cpu_exec: executing tb=%p pc=0x%lx\n", tb,
+                    DPRINTF("cpu_exec: executing tb=%p pc=0x%lx\n", tb,
                             (long)tb->pc);
                 /* execute the generated code */
 #if defined(__sparc__) && !defined(HOST_SOLARIS)
@@ -625,7 +626,7 @@ int cpu_exec(CPUState *env1)
 #define env cpu_single_env
 #endif
                     next_tb = tcg_qemu_tb_exec(tc_ptr);
-                    fprintf(stderr, "cpu_exec: next_tb=0x%lx after tb=%p\n",
+                    DPRINTF("cpu_exec: next_tb=0x%lx after tb=%p\n",
                             next_tb, tb);
                     env->current_tb = NULL;
                     if ((next_tb & 3) == 2) {
@@ -772,7 +773,7 @@ static inline int handle_cpu_signal(unsigned long pc, unsigned long address,
 {
     TranslationBlock *tb;
     int ret;
-    fprintf(stderr, "handle_cpu_signal: pc=0x%lx address=0x%lx write=%d\n",
+    DPRINTF("handle_cpu_signal: pc=0x%lx address=0x%lx write=%d\n",
             pc, address, is_write);
 
     if (cpu_single_env)

--- a/qemu-0.10.0/debug_print.h
+++ b/qemu-0.10.0/debug_print.h
@@ -1,0 +1,6 @@
+#ifndef DEBUG_PRINT_H
+#define DEBUG_PRINT_H
+#include <stdio.h>
+extern int debug_prints;
+#define DPRINTF(...) do { if (debug_prints) fprintf(stderr, __VA_ARGS__); } while (0)
+#endif /* DEBUG_PRINT_H */

--- a/qemu-0.10.0/exec.c
+++ b/qemu-0.10.0/exec.c
@@ -27,6 +27,7 @@
 #endif
 #include <stdlib.h>
 #include <stdio.h>
+#include "debug_print.h"
 #include <stdarg.h>
 #include <string.h>
 #include <errno.h>
@@ -854,7 +855,7 @@ TranslationBlock *tb_gen_code(CPUState *env,
     target_ulong phys_pc, phys_page2, virt_page2;
     int code_gen_size;
 
-    fprintf(stderr, "tb_gen_code: env=%p pc=0x%lx cs_base=0x%lx flags=0x%x\n",
+    DPRINTF("tb_gen_code: env=%p pc=0x%lx cs_base=0x%lx flags=0x%x\n",
             env, (long)pc, (long)cs_base, flags);
 
     phys_pc = get_phys_addr_code(env, pc);
@@ -873,7 +874,7 @@ TranslationBlock *tb_gen_code(CPUState *env,
     tb->flags = flags;
     tb->cflags = cflags;
     cpu_gen_code(env, tb, &code_gen_size);
-    fprintf(stderr, "tb_gen_code: generated tb=%p tc_ptr=%p size=%d\n", tb,
+    DPRINTF("tb_gen_code: generated tb=%p tc_ptr=%p size=%d\n", tb,
             tc_ptr, code_gen_size);
     code_gen_ptr = (void *)(((unsigned long)code_gen_ptr + code_gen_size + CODE_GEN_ALIGN - 1) & ~(CODE_GEN_ALIGN - 1));
 
@@ -884,7 +885,7 @@ TranslationBlock *tb_gen_code(CPUState *env,
         phys_page2 = get_phys_addr_code(env, virt_page2);
     }
     tb_link_phys(tb, phys_pc, phys_page2);
-    fprintf(stderr, "tb_gen_code: linked tb=%p phys_pc=0x%lx phys_page2=0x%lx\n",
+    DPRINTF("tb_gen_code: linked tb=%p phys_pc=0x%lx phys_page2=0x%lx\n",
             tb, (long)phys_pc, (long)phys_page2);
     return tb;
 }

--- a/qemu-0.10.0/vl.c
+++ b/qemu-0.10.0/vl.c
@@ -38,6 +38,7 @@
 #include "qemu-timer.h"
 #include "qemu-char.h"
 #include "cache-utils.h"
+#include "debug_print.h"
 #include "block.h"
 #include "audio/audio.h"
 #include "migration.h"
@@ -326,6 +327,7 @@ int semihosting_enabled = 0;
 int old_param = 0;
 #endif
 const char *qemu_name;
+int debug_prints = 0;
 int alt_grab = 0;
 #if defined(TARGET_SPARC) || defined(TARGET_PPC)
 unsigned int nb_prom_envs = 0;
@@ -3833,7 +3835,7 @@ static int main_loop(void)
 #endif
     CPUState *env;
 
-    fprintf(stderr, "main_loop: start\n");
+    DPRINTF("main_loop: start\n");
 
     cur_cpu = first_cpu;
     next_cpu = cur_cpu->next_cpu ?: first_cpu;
@@ -3861,10 +3863,10 @@ static int main_loop(void)
                     env->icount_decr.u16.low = decr;
                     env->icount_extra = count;
                 }
-                fprintf(stderr, "main_loop: executing CPU env=%p pc=0x%lx\n", env,
+                DPRINTF("main_loop: executing CPU env=%p pc=0x%lx\n", env,
                         (long)env->eip);
                 ret = cpu_exec(env);
-                fprintf(stderr, "main_loop: cpu_exec returned %d\n", ret);
+                DPRINTF("main_loop: cpu_exec returned %d\n", ret);
 #ifdef CONFIG_PROFILER
             qemu_time += profile_getclock() - ti;
 #endif
@@ -4731,6 +4733,10 @@ int main(int argc, char **argv, char **envp)
     struct passwd *pwd = NULL;
     const char *chroot_dir = NULL;
     const char *run_as = NULL;
+
+    const char *dbg = getenv("DEBUG_PRINTS");
+    if (dbg && *dbg && strcmp(dbg, "0") != 0)
+        debug_prints = 1;
 
     qemu_cache_utils_init(envp);
 

--- a/scripts/run_test_disk.sh
+++ b/scripts/run_test_disk.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -e
 
+# Optional: set QUIET=1 to suppress command output
+
 # Simple helper to create a qcow2 disk image and boot QEMU with it.
 # Usage: ./scripts/run_test_disk.sh [image] [size]
 # Default image name is 'disk.img' and size is 64M.
@@ -9,9 +11,17 @@ SIZE=${2:-64M}
 
 # Create disk image if it doesn't already exist
 if [ ! -f "$IMG" ]; then
-    echo "Creating $IMG of size $SIZE"
-    qemu-img create -f qcow2 "$IMG" "$SIZE"
+    [ "$QUIET" = "1" ] || echo "Creating $IMG of size $SIZE"
+    if [ "$QUIET" = "1" ]; then
+        qemu-img create -f qcow2 "$IMG" "$SIZE" >/dev/null 2>&1
+    else
+        qemu-img create -f qcow2 "$IMG" "$SIZE"
+    fi
 fi
 
 cd qemu-0.10.0
-exec ./i386-softmmu/qemu -L ./pc-bios -hda "../$IMG" -m 64
+if [ "$QUIET" = "1" ]; then
+    exec ./i386-softmmu/qemu -L ./pc-bios -hda "../$IMG" -m 64 >/dev/null 2>&1
+else
+    exec ./i386-softmmu/qemu -L ./pc-bios -hda "../$IMG" -m 64
+fi


### PR DESCRIPTION
## Summary
- add a small `debug_print.h` helper
- wrap previous debug prints in `DPRINTF`
- enable debug printing with `DEBUG_PRINTS=1`
- show `-cdrom` example in README

## Testing
- `shellcheck scripts/run_test_disk.sh`
- `sh -n scripts/run_test_disk.sh`
- `./configure --target-list=i386-softmmu --disable-sdl --disable-gfx-check` *(fails: ERROR: QEMU requires SDL or Cocoa for graphical output)*


------
https://chatgpt.com/codex/tasks/task_e_685137a75a24832c8a5ec7dfd9c17bd1