### PR TITLE
Improve cue file parsing

### DIFF
--- a/qemu-0.10.0/cpu-exec.c
+++ b/qemu-0.10.0/cpu-exec.c
@@ -54,7 +54,9 @@ int tb_invalidated_flag;
 
 void cpu_loop_exit(void)
 {
+#ifdef DEBUG_EXEC
     fprintf(stderr, "cpu_loop_exit: env=%p\n", env);
+#endif
     /* NOTE: the register at this point must be saved by hand because
        longjmp restore them */
     regs_to_env();
@@ -99,8 +101,10 @@ static void cpu_exec_nocache(int max_cycles, TranslationBlock *orig_tb)
     unsigned long next_tb;
     TranslationBlock *tb;
 
+#ifdef DEBUG_EXEC
     fprintf(stderr, "cpu_exec_nocache: pc=0x%lx flags=0x%x\n",
             (long)orig_tb->pc, orig_tb->flags);
+#endif
 
     /* Should never happen.
        We only end up here when an existing TB is too long.  */
@@ -129,7 +133,9 @@ static TranslationBlock *tb_find_slow(target_ulong pc,
     TranslationBlock *tb, **ptb1;
     unsigned int h;
     target_ulong phys_pc, phys_page1, phys_page2, virt_page2;
+#ifdef DEBUG_EXEC
     fprintf(stderr, "tb_find_slow: pc=0x%lx cs_base=0x%lx flags=0x%lx\n", (long)pc, (long)cs_base, (long)flags);
+#endif
 
     tb_invalidated_flag = 0;
 
@@ -165,12 +171,16 @@ static TranslationBlock *tb_find_slow(target_ulong pc,
  not_found:
   /* if no translated code available, then translate it now */
     tb = tb_gen_code(env, pc, cs_base, flags, 0);
+#ifdef DEBUG_EXEC
     fprintf(stderr, "tb_find_slow: generated tb=%p for pc=0x%lx\n", tb, (long)pc);
+#endif
 
  found:
   /* we add the TB in the virtual pc hash table */
+#ifdef DEBUG_EXEC
     fprintf(stderr, "tb_find_slow: storing tb=%p in jmp_cache index=%zu\n", tb,
             (size_t)tb_jmp_cache_hash_func(pc));
+#endif
     env->tb_jmp_cache[tb_jmp_cache_hash_func(pc)] = tb;
     return tb;
 }
@@ -226,8 +236,10 @@ int cpu_exec(CPUState *env1)
     uint8_t *tc_ptr;
     unsigned long next_tb;
 
+#ifdef DEBUG_EXEC
     fprintf(stderr, "cpu_exec: start env=%p eip=0x%lx\n",
             env1, (long)env1->eip);
+#endif
 
     if (cpu_halted(env1) == EXCP_HALTED)
         return EXCP_HALTED;
@@ -616,8 +628,10 @@ int cpu_exec(CPUState *env1)
 
                 while (env->current_tb) {
                     tc_ptr = tb->tc_ptr;
+#ifdef DEBUG_EXEC
                     fprintf(stderr, "cpu_exec: executing tb=%p pc=0x%lx\n", tb,
                             (long)tb->pc);
+#endif
                 /* execute the generated code */
 #if defined(__sparc__) && !defined(HOST_SOLARIS)
 #undef env
@@ -625,8 +639,10 @@ int cpu_exec(CPUState *env1)
 #define env cpu_single_env
 #endif
                     next_tb = tcg_qemu_tb_exec(tc_ptr);
+#ifdef DEBUG_EXEC
                     fprintf(stderr, "cpu_exec: next_tb=0x%lx after tb=%p\n",
                             next_tb, tb);
+#endif
                     env->current_tb = NULL;
                     if ((next_tb & 3) == 2) {
                         /* Instruction counter expired.  */
@@ -772,8 +788,10 @@ static inline int handle_cpu_signal(unsigned long pc, unsigned long address,
 {
     TranslationBlock *tb;
     int ret;
+#ifdef DEBUG_EXEC
     fprintf(stderr, "handle_cpu_signal: pc=0x%lx address=0x%lx write=%d\n",
             pc, address, is_write);
+#endif
 
     if (cpu_single_env)
         env = cpu_single_env; /* XXX: find a correct solution for multithread */

--- a/qemu-0.10.0/exec.c
+++ b/qemu-0.10.0/exec.c
@@ -55,6 +55,7 @@
 
 //#define DEBUG_IOPORT
 //#define DEBUG_SUBPAGE
+//#define DEBUG_EXEC
 
 #if !defined(CONFIG_USER_ONLY)
 /* TB consistency checks only implemented for usermode emulation.  */
@@ -854,8 +855,10 @@ TranslationBlock *tb_gen_code(CPUState *env,
     target_ulong phys_pc, phys_page2, virt_page2;
     int code_gen_size;
 
+#ifdef DEBUG_EXEC
     fprintf(stderr, "tb_gen_code: env=%p pc=0x%lx cs_base=0x%lx flags=0x%x\n",
             env, (long)pc, (long)cs_base, flags);
+#endif
 
     phys_pc = get_phys_addr_code(env, pc);
     tb = tb_alloc(pc);
@@ -873,8 +876,10 @@ TranslationBlock *tb_gen_code(CPUState *env,
     tb->flags = flags;
     tb->cflags = cflags;
     cpu_gen_code(env, tb, &code_gen_size);
+#ifdef DEBUG_EXEC
     fprintf(stderr, "tb_gen_code: generated tb=%p tc_ptr=%p size=%d\n", tb,
             tc_ptr, code_gen_size);
+#endif
     code_gen_ptr = (void *)(((unsigned long)code_gen_ptr + code_gen_size + CODE_GEN_ALIGN - 1) & ~(CODE_GEN_ALIGN - 1));
 
     /* check next page if needed */
@@ -884,8 +889,10 @@ TranslationBlock *tb_gen_code(CPUState *env,
         phys_page2 = get_phys_addr_code(env, virt_page2);
     }
     tb_link_phys(tb, phys_pc, phys_page2);
+#ifdef DEBUG_EXEC
     fprintf(stderr, "tb_gen_code: linked tb=%p phys_pc=0x%lx phys_page2=0x%lx\n",
             tb, (long)phys_pc, (long)phys_page2);
+#endif
     return tb;
 }
 

--- a/qemu-0.10.0/hw/cdaudio.c
+++ b/qemu-0.10.0/hw/cdaudio.c
@@ -2,15 +2,6 @@
 #include "cdaudio.h"
 #include "bswap.h"
 
-/* Enable verbose CD audio debug output */
-//#define DEBUG_CDAUDIO
-#ifdef DEBUG_CDAUDIO
-# define CDAUDIO_DPRINTF(fmt, ...) \
-    fprintf(stderr, "cdaudio: " fmt, ## __VA_ARGS__)
-#else
-# define CDAUDIO_DPRINTF(fmt, ...) do { } while (0)
-#endif
-
 #ifdef CONFIG_CDAUDIO
 
 typedef struct CDAudioState {
@@ -28,6 +19,9 @@ static void cdaudio_callback(void *opaque, int free)
 {
     CDAudioState *s = opaque;
     uint8_t sector[2352];
+
+    CDAUDIO_DPRINTF("callback free=%d play=%d cur=%d end=%d\n", free,
+                    s->playing, s->cur_lba, s->end_lba);
 
     while (free >= 2352 && s->playing && s->cur_lba < s->end_lba) {
         if (!s->bs)

--- a/qemu-0.10.0/hw/cdaudio.h
+++ b/qemu-0.10.0/hw/cdaudio.h
@@ -4,6 +4,15 @@
 #include "block.h"
 #include "audio/audio.h"
 
+/* Enable verbose CD audio debug output */
+//#define DEBUG_CDAUDIO
+#ifdef DEBUG_CDAUDIO
+# define CDAUDIO_DPRINTF(fmt, ...) \
+    fprintf(stderr, "cdaudio: " fmt, ## __VA_ARGS__)
+#else
+# define CDAUDIO_DPRINTF(fmt, ...) do { } while (0)
+#endif
+
 #ifdef CONFIG_CDAUDIO
 void cdaudio_init(BlockDriverState *bs);
 void cdaudio_set_bs(BlockDriverState *bs);

--- a/qemu-0.10.0/hw/ide.c
+++ b/qemu-0.10.0/hw/ide.c
@@ -1805,6 +1805,7 @@ static void ide_atapi_cmd(IDEState *s)
             lba = ube32_to_cpu(packet + 2);
             nb_sectors = ube16_to_cpu(packet + 7);
             cdaudio_set_bs(s->bs);
+            CDAUDIO_DPRINTF("PLAY_AUDIO_10 lba=%d count=%d\n", lba, nb_sectors);
             cdaudio_play_lba(lba, nb_sectors);
             ide_atapi_cmd_ok(s);
         }
@@ -1813,6 +1814,7 @@ static void ide_atapi_cmd(IDEState *s)
         { int start_lba = msf_to_lba_local(packet[3], packet[4], packet[5]);
           int end_lba = msf_to_lba_local(packet[6], packet[7], packet[8]);
           cdaudio_set_bs(s->bs);
+          CDAUDIO_DPRINTF("PLAY_AUDIO_MSF start=%d end=%d\n", start_lba, end_lba);
           cdaudio_play_lba(start_lba, end_lba - start_lba); }
         ide_atapi_cmd_ok(s);
         break;
@@ -1821,10 +1823,12 @@ static void ide_atapi_cmd(IDEState *s)
         ide_atapi_cmd_ok(s);
         break;
     case GPCMD_PAUSE_RESUME:
+        CDAUDIO_DPRINTF("PAUSE_RESUME %d\n", packet[8] & 1);
         if (packet[8] & 1) { cdaudio_pause(1); } else { cdaudio_pause(0); }
         ide_atapi_cmd_ok(s);
         break;
     case GPCMD_STOP_PLAY_SCAN:
+        CDAUDIO_DPRINTF("STOP_PLAY_SCAN\n");
         cdaudio_stop();
         ide_atapi_cmd_ok(s);
         break;
@@ -2119,6 +2123,7 @@ static void cdrom_change_cb(void *opaque)
 {
     IDEState *s = opaque;
     cdaudio_set_bs(s->bs);
+    CDAUDIO_DPRINTF("cdrom changed\n");
     uint64_t nb_sectors;
 
     bdrv_get_geometry(s->bs, &nb_sectors);

--- a/qemu-0.10.0/vl.c
+++ b/qemu-0.10.0/vl.c
@@ -2259,6 +2259,11 @@ int drive_add(const char *file, const char *fmt, ...)
     }
 
     drives_opt[index].file = file;
+    if (file) {
+        fprintf(stderr, "drive_add: registering image '%s' (%s)\n", file, fmt);
+    } else {
+        fprintf(stderr, "drive_add: registering empty drive (%s)\n", fmt);
+    }
     va_start(ap, fmt);
     vsnprintf(drives_opt[index].opt,
               sizeof(drives_opt[0].opt), fmt, ap);
@@ -4970,7 +4975,21 @@ int main(int argc, char **argv, char **envp)
                 kernel_cmdline = optarg;
                 break;
             case QEMU_OPTION_cdrom:
+#ifdef CONFIG_CDAUDIO
+                {
+                    char cuepath[1024];
+                    if (cue_extract_bin(optarg, cuepath, sizeof(cuepath)) == 0) {
+                        fprintf(stderr, "drive option cdrom: using bin '%s' extracted from '%s'\n",
+                                cuepath, optarg);
+                        drive_add(cuepath, CDROM_ALIAS);
+                    } else {
+                        fprintf(stderr, "drive option cdrom: using image '%s'\n", optarg);
+                        drive_add(optarg, CDROM_ALIAS);
+                    }
+                }
+#else
                 drive_add(optarg, CDROM_ALIAS);
+#endif
                 break;
             case QEMU_OPTION_boot:
                 boot_devices = optarg;

--- a/qemu-0.10.0/vl.c
+++ b/qemu-0.10.0/vl.c
@@ -153,6 +153,7 @@ static int cue_extract_bin(const char *cuefile, char *out, int out_size)
     FILE *f = fopen(cuefile, "r");
     char line[LINE_BUF_LEN];
     char dir[1024];
+    char first_file[1024] = "";
     const char *p;
     int cur_is_audio = 0;
 
@@ -176,29 +177,21 @@ static int cue_extract_bin(const char *cuefile, char *out, int out_size)
         dir[0] = '\0';
 
     while (fgets(line, sizeof(line), f)) {
-        if (strstr(line, "FILE")) {
-            char *q = strchr(line, '"');
-            if (!q)
-                continue;
-            q++;
-            p = strchr(q, '"');
-            if (!p)
-                continue;
-            int len = p - q;
-            if (len > sizeof(cue_sheet.bin_path) - 1)
-                len = sizeof(cue_sheet.bin_path) - 1;
-            memcpy(cue_sheet.bin_path, q, len);
-            cue_sheet.bin_path[len] = '\0';
-            if (!path_is_absolute(cue_sheet.bin_path)) {
-                char tmp[1024];
-                path_combine(tmp, sizeof(tmp), dir, cue_sheet.bin_path);
-                pstrcpy(cue_sheet.bin_path, sizeof(cue_sheet.bin_path), tmp);
+        char keyword[16];
+        if (sscanf(line, " %15s", keyword) != 1)
+            continue;
+
+        if (!strcasecmp(keyword, "FILE")) {
+            char filename[1024];
+            if (sscanf(line, " FILE \"%1023[^\"]\"", filename) == 1) {
+                if (first_file[0] == '\0')
+                    pstrcpy(first_file, sizeof(first_file), filename);
             }
-        } else if (strstr(line, "TRACK")) {
-            cur_is_audio = strstr(line, "AUDIO") != NULL;
-        } else if (strstr(line, "INDEX 01")) {
-            int m, s, fframe;
-            if (sscanf(line, "%*s %*s %d:%d:%d", &m, &s, &fframe) == 3) {
+        } else if (!strcasecmp(keyword, "TRACK")) {
+            cur_is_audio = (strstr(line, "AUDIO") != NULL);
+        } else if (!strcasecmp(keyword, "INDEX")) {
+            int index, m, s, fframe;
+            if (sscanf(line, " INDEX %d %d:%d:%d", &index, &m, &s, &fframe) == 4 && index == 1) {
                 if (cue_sheet.track_count < 100) {
                     cue_sheet.tracks[cue_sheet.track_count].lba = msf_to_lba(m, s, fframe);
                     cue_sheet.tracks[cue_sheet.track_count].is_audio = cur_is_audio;
@@ -209,7 +202,13 @@ static int cue_extract_bin(const char *cuefile, char *out, int out_size)
     }
     fclose(f);
 
-    if (cue_sheet.track_count > 0) {
+    if (cue_sheet.track_count > 0 && first_file[0]) {
+        pstrcpy(cue_sheet.bin_path, sizeof(cue_sheet.bin_path), first_file);
+        if (!path_is_absolute(cue_sheet.bin_path)) {
+            char tmp[1024];
+            path_combine(tmp, sizeof(tmp), dir, cue_sheet.bin_path);
+            pstrcpy(cue_sheet.bin_path, sizeof(cue_sheet.bin_path), tmp);
+        }
         pstrcpy(out, out_size, cue_sheet.bin_path);
         return 0;
     }


### PR DESCRIPTION
## Summary
- improve `cue_extract_bin()` to parse keywords more robustly
- ensure the first FILE path is captured and track info parsed despite extra commands

## Testing
- `./configure --target-list=i386-softmmu --enable-cdaudio`
- `make -j$(nproc)`
- `./scripts/run_test_disk.sh` *(fails: `qemu: could not load PC BIOS`)*

------
https://chatgpt.com/codex/tasks/task_e_68518e15040c832c9d4cdd7cc62a130d