### PR TITLE
Add CD audio debug instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,21 @@ After building, you can create a small qcow2 disk image and boot QEMU with it:
 
 The script uses `qemu-img` to create a 64MB image if it does not exist and
 passes it as the `-hda` drive.
+
+## Debugging CD audio
+
+To print verbose messages from the CD audio code while leaving other
+components quiet, build QEMU with the `DEBUG_CDAUDIO` define enabled:
+
+```sh
+cd qemu-0.10.0
+./configure --target-list=i386-softmmu --enable-cdaudio CFLAGS="-DDEBUG_CDAUDIO"
+make -j$(nproc)
+```
+
+CPU execution traces remain disabled unless you also define `DEBUG_EXEC`.
+Run QEMU with for example:
+
+```sh
+QEMU_AUDIO_DRV=alsa ./i386-softmmu/qemu -L pc-bios -cdrom spl.cue -hda DISKDOS.IMG -boot c -m 64 -soundhw sb16
+```

--- a/qemu-0.10.0/compilation.sh
+++ b/qemu-0.10.0/compilation.sh
@@ -1,0 +1,5 @@
+export CFLAGS="-m32 -DDEBUG_CDAUDIO"
+export LDFLAGS="-m32 -no-pie"
+./configure --target-list=i386-softmmu  --enable-cdaudio
+make clean
+make

--- a/qemu-0.10.0/cpu-exec.c
+++ b/qemu-0.10.0/cpu-exec.c
@@ -54,7 +54,9 @@ int tb_invalidated_flag;
 
 void cpu_loop_exit(void)
 {
+#ifdef DEBUG_EXEC
     fprintf(stderr, "cpu_loop_exit: env=%p\n", env);
+#endif
     /* NOTE: the register at this point must be saved by hand because
        longjmp restore them */
     regs_to_env();
@@ -99,8 +101,10 @@ static void cpu_exec_nocache(int max_cycles, TranslationBlock *orig_tb)
     unsigned long next_tb;
     TranslationBlock *tb;
 
+#ifdef DEBUG_EXEC
     fprintf(stderr, "cpu_exec_nocache: pc=0x%lx flags=0x%x\n",
             (long)orig_tb->pc, orig_tb->flags);
+#endif
 
     /* Should never happen.
        We only end up here when an existing TB is too long.  */
@@ -129,7 +133,9 @@ static TranslationBlock *tb_find_slow(target_ulong pc,
     TranslationBlock *tb, **ptb1;
     unsigned int h;
     target_ulong phys_pc, phys_page1, phys_page2, virt_page2;
+#ifdef DEBUG_EXEC
     fprintf(stderr, "tb_find_slow: pc=0x%lx cs_base=0x%lx flags=0x%lx\n", (long)pc, (long)cs_base, (long)flags);
+#endif
 
     tb_invalidated_flag = 0;
 
@@ -165,12 +171,16 @@ static TranslationBlock *tb_find_slow(target_ulong pc,
  not_found:
   /* if no translated code available, then translate it now */
     tb = tb_gen_code(env, pc, cs_base, flags, 0);
+#ifdef DEBUG_EXEC
     fprintf(stderr, "tb_find_slow: generated tb=%p for pc=0x%lx\n", tb, (long)pc);
+#endif
 
  found:
   /* we add the TB in the virtual pc hash table */
+#ifdef DEBUG_EXEC
     fprintf(stderr, "tb_find_slow: storing tb=%p in jmp_cache index=%zu\n", tb,
             (size_t)tb_jmp_cache_hash_func(pc));
+#endif
     env->tb_jmp_cache[tb_jmp_cache_hash_func(pc)] = tb;
     return tb;
 }
@@ -226,8 +236,10 @@ int cpu_exec(CPUState *env1)
     uint8_t *tc_ptr;
     unsigned long next_tb;
 
+#ifdef DEBUG_EXEC
     fprintf(stderr, "cpu_exec: start env=%p eip=0x%lx\n",
             env1, (long)env1->eip);
+#endif
 
     if (cpu_halted(env1) == EXCP_HALTED)
         return EXCP_HALTED;
@@ -616,8 +628,10 @@ int cpu_exec(CPUState *env1)
 
                 while (env->current_tb) {
                     tc_ptr = tb->tc_ptr;
+#ifdef DEBUG_EXEC
                     fprintf(stderr, "cpu_exec: executing tb=%p pc=0x%lx\n", tb,
                             (long)tb->pc);
+#endif
                 /* execute the generated code */
 #if defined(__sparc__) && !defined(HOST_SOLARIS)
 #undef env
@@ -625,8 +639,10 @@ int cpu_exec(CPUState *env1)
 #define env cpu_single_env
 #endif
                     next_tb = tcg_qemu_tb_exec(tc_ptr);
+#ifdef DEBUG_EXEC
                     fprintf(stderr, "cpu_exec: next_tb=0x%lx after tb=%p\n",
                             next_tb, tb);
+#endif
                     env->current_tb = NULL;
                     if ((next_tb & 3) == 2) {
                         /* Instruction counter expired.  */
@@ -772,8 +788,10 @@ static inline int handle_cpu_signal(unsigned long pc, unsigned long address,
 {
     TranslationBlock *tb;
     int ret;
+#ifdef DEBUG_EXEC
     fprintf(stderr, "handle_cpu_signal: pc=0x%lx address=0x%lx write=%d\n",
             pc, address, is_write);
+#endif
 
     if (cpu_single_env)
         env = cpu_single_env; /* XXX: find a correct solution for multithread */

--- a/qemu-0.10.0/exec.c
+++ b/qemu-0.10.0/exec.c
@@ -55,6 +55,7 @@
 
 //#define DEBUG_IOPORT
 //#define DEBUG_SUBPAGE
+//#define DEBUG_EXEC
 
 #if !defined(CONFIG_USER_ONLY)
 /* TB consistency checks only implemented for usermode emulation.  */
@@ -854,8 +855,10 @@ TranslationBlock *tb_gen_code(CPUState *env,
     target_ulong phys_pc, phys_page2, virt_page2;
     int code_gen_size;
 
+#ifdef DEBUG_EXEC
     fprintf(stderr, "tb_gen_code: env=%p pc=0x%lx cs_base=0x%lx flags=0x%x\n",
             env, (long)pc, (long)cs_base, flags);
+#endif
 
     phys_pc = get_phys_addr_code(env, pc);
     tb = tb_alloc(pc);
@@ -873,8 +876,10 @@ TranslationBlock *tb_gen_code(CPUState *env,
     tb->flags = flags;
     tb->cflags = cflags;
     cpu_gen_code(env, tb, &code_gen_size);
+#ifdef DEBUG_EXEC
     fprintf(stderr, "tb_gen_code: generated tb=%p tc_ptr=%p size=%d\n", tb,
             tc_ptr, code_gen_size);
+#endif
     code_gen_ptr = (void *)(((unsigned long)code_gen_ptr + code_gen_size + CODE_GEN_ALIGN - 1) & ~(CODE_GEN_ALIGN - 1));
 
     /* check next page if needed */
@@ -884,8 +889,10 @@ TranslationBlock *tb_gen_code(CPUState *env,
         phys_page2 = get_phys_addr_code(env, virt_page2);
     }
     tb_link_phys(tb, phys_pc, phys_page2);
+#ifdef DEBUG_EXEC
     fprintf(stderr, "tb_gen_code: linked tb=%p phys_pc=0x%lx phys_page2=0x%lx\n",
             tb, (long)phys_pc, (long)phys_page2);
+#endif
     return tb;
 }
 

--- a/qemu-0.10.0/hw/cdaudio.c
+++ b/qemu-0.10.0/hw/cdaudio.c
@@ -20,9 +20,13 @@ static void cdaudio_callback(void *opaque, int free)
     CDAudioState *s = opaque;
     uint8_t sector[2352];
 
+    CDAUDIO_DPRINTF("callback free=%d play=%d cur=%d end=%d\n", free,
+                    s->playing, s->cur_lba, s->end_lba);
+
     while (free >= 2352 && s->playing && s->cur_lba < s->end_lba) {
         if (!s->bs)
             break;
+        CDAUDIO_DPRINTF("read lba=%d\n", s->cur_lba);
         if (bdrv_pread(s->bs, (int64_t)s->cur_lba * 2352, sector, 2352) != 2352)
             break;
 #ifndef WORDS_BIGENDIAN
@@ -49,17 +53,20 @@ void cdaudio_init(BlockDriverState *bs)
     AUD_register_card(audio, "cdaudio", &cd_audio.card);
     cd_audio.voice = AUD_open_out(&cd_audio.card, NULL, "cdaudio",
                                   &cd_audio, cdaudio_callback, &as);
+    CDAUDIO_DPRINTF("init bs=%p\n", bs);
 }
 
 void cdaudio_set_bs(BlockDriverState *bs)
 {
     cd_audio.bs = bs;
+    CDAUDIO_DPRINTF("set_bs %p\n", bs);
 }
 
 void cdaudio_play_lba(int start_lba, int nb_sectors)
 {
     if (!cd_audio.voice)
         cdaudio_init(cd_audio.bs);
+    CDAUDIO_DPRINTF("play_lba start=%d count=%d\n", start_lba, nb_sectors);
     cd_audio.cur_lba = start_lba;
     cd_audio.end_lba = start_lba + nb_sectors;
     cd_audio.playing = 1;
@@ -70,11 +77,13 @@ void cdaudio_pause(int active)
 {
     if (cd_audio.voice)
         AUD_set_active_out(cd_audio.voice, active);
+    CDAUDIO_DPRINTF("pause %d\n", active);
 }
 
 void cdaudio_stop(void)
 {
     cd_audio.playing = 0;
+    CDAUDIO_DPRINTF("stop\n");
     if (cd_audio.voice)
         AUD_set_active_out(cd_audio.voice, 0);
 }

--- a/qemu-0.10.0/hw/cdaudio.h
+++ b/qemu-0.10.0/hw/cdaudio.h
@@ -4,6 +4,15 @@
 #include "block.h"
 #include "audio/audio.h"
 
+/* Enable verbose CD audio debug output */
+//#define DEBUG_CDAUDIO
+#ifdef DEBUG_CDAUDIO
+# define CDAUDIO_DPRINTF(fmt, ...) \
+    fprintf(stderr, "cdaudio: " fmt, ## __VA_ARGS__)
+#else
+# define CDAUDIO_DPRINTF(fmt, ...) do { } while (0)
+#endif
+
 #ifdef CONFIG_CDAUDIO
 void cdaudio_init(BlockDriverState *bs);
 void cdaudio_set_bs(BlockDriverState *bs);

--- a/qemu-0.10.0/hw/ide.c
+++ b/qemu-0.10.0/hw/ide.c
@@ -1805,6 +1805,7 @@ static void ide_atapi_cmd(IDEState *s)
             lba = ube32_to_cpu(packet + 2);
             nb_sectors = ube16_to_cpu(packet + 7);
             cdaudio_set_bs(s->bs);
+            CDAUDIO_DPRINTF("PLAY_AUDIO_10 lba=%d count=%d\n", lba, nb_sectors);
             cdaudio_play_lba(lba, nb_sectors);
             ide_atapi_cmd_ok(s);
         }
@@ -1813,6 +1814,7 @@ static void ide_atapi_cmd(IDEState *s)
         { int start_lba = msf_to_lba_local(packet[3], packet[4], packet[5]);
           int end_lba = msf_to_lba_local(packet[6], packet[7], packet[8]);
           cdaudio_set_bs(s->bs);
+          CDAUDIO_DPRINTF("PLAY_AUDIO_MSF start=%d end=%d\n", start_lba, end_lba);
           cdaudio_play_lba(start_lba, end_lba - start_lba); }
         ide_atapi_cmd_ok(s);
         break;
@@ -1821,10 +1823,12 @@ static void ide_atapi_cmd(IDEState *s)
         ide_atapi_cmd_ok(s);
         break;
     case GPCMD_PAUSE_RESUME:
+        CDAUDIO_DPRINTF("PAUSE_RESUME %d\n", packet[8] & 1);
         if (packet[8] & 1) { cdaudio_pause(1); } else { cdaudio_pause(0); }
         ide_atapi_cmd_ok(s);
         break;
     case GPCMD_STOP_PLAY_SCAN:
+        CDAUDIO_DPRINTF("STOP_PLAY_SCAN\n");
         cdaudio_stop();
         ide_atapi_cmd_ok(s);
         break;
@@ -2119,6 +2123,7 @@ static void cdrom_change_cb(void *opaque)
 {
     IDEState *s = opaque;
     cdaudio_set_bs(s->bs);
+    CDAUDIO_DPRINTF("cdrom changed\n");
     uint64_t nb_sectors;
 
     bdrv_get_geometry(s->bs, &nb_sectors);

--- a/qemu-0.10.0/vl.c
+++ b/qemu-0.10.0/vl.c
@@ -3832,7 +3832,6 @@ static int main_loop(void)
 #endif
     CPUState *env;
 
-    fprintf(stderr, "main_loop: start\n");
 
     cur_cpu = first_cpu;
     next_cpu = cur_cpu->next_cpu ?: first_cpu;
@@ -3860,10 +3859,7 @@ static int main_loop(void)
                     env->icount_decr.u16.low = decr;
                     env->icount_extra = count;
                 }
-                fprintf(stderr, "main_loop: executing CPU env=%p pc=0x%lx\n", env,
-                        (long)env->eip);
                 ret = cpu_exec(env);
-                fprintf(stderr, "main_loop: cpu_exec returned %d\n", ret);
 #ifdef CONFIG_PROFILER
             qemu_time += profile_getclock() - ti;
 #endif


### PR DESCRIPTION
## Summary
- remove drive add and cdrom option debug prints
- document how to build with `DEBUG_CDAUDIO`
- example run command for CD audio debugging

## Testing
- `CFLAGS="-DDEBUG_CDAUDIO" ./configure --target-list=i386-softmmu --enable-cdaudio --disable-sdl --disable-gfx-check`
- `make -j$(nproc)` *(failed: build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68518e15040c832c9d4cdd7cc62a130d