### PR TITLE
Remove debug output

### DIFF
--- a/qemu-0.10.0/vl.c
+++ b/qemu-0.10.0/vl.c
@@ -3832,7 +3832,6 @@ static int main_loop(void)
 #endif
     CPUState *env;
 
-    fprintf(stderr, "main_loop: start\n");
 
     cur_cpu = first_cpu;
     next_cpu = cur_cpu->next_cpu ?: first_cpu;
@@ -3860,10 +3859,7 @@ static int main_loop(void)
                     env->icount_decr.u16.low = decr;
                     env->icount_extra = count;
                 }
-                fprintf(stderr, "main_loop: executing CPU env=%p pc=0x%lx\n", env,
-                        (long)env->eip);
                 ret = cpu_exec(env);
-                fprintf(stderr, "main_loop: cpu_exec returned %d\n", ret);
 #ifdef CONFIG_PROFILER
             qemu_time += profile_getclock() - ti;
 #endif


### PR DESCRIPTION
## Summary
- strip unnecessary `main_loop` debug prints

## Testing
- `make -C qemu-0.10.0/tests test` *(fails: `../i386-linux-user/qemu-i386: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68519f25568c832cbf1fc67e95a79b15